### PR TITLE
fix(incoming_link): respect clients incoming delivery count

### DIFF
--- a/src/rabbit_amqp1_0_incoming_link.erl
+++ b/src/rabbit_amqp1_0_incoming_link.erl
@@ -47,7 +47,8 @@ attach(#'v1_0.attach'{name = Name,
     case ensure_target(Target,
                        #incoming_link{
                          name        = Name,
-                         route_state = rabbit_routing_util:init_state() },
+                         route_state = rabbit_routing_util:init_state(),
+                         delivery_count = InitTransfer },
                        DCh) of
         {ok, ServerTarget,
          IncomingLink = #incoming_link{ delivery_count = InitTransfer }} ->


### PR DESCRIPTION
Per section 2.6.7 of the AMQP 1.0 spec: "Note that, despite
its name, the delivery-count is not a count but a sequence number
initialized at an arbitrary point by the sender"

RabbitMQ's AMQP 1.0 module assumed a delivery_count of 0, and
should instead respect the initial delivery count sent by the
client.