### PR TITLE
set environment to python2

### DIFF
--- a/codegen.py
+++ b/codegen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import os
 import re


### PR DESCRIPTION
This allows building on systems that default python to python3
while still selecting python2 on systems where python2 is the
default.