### PR TITLE
Ensure queues are created with auto-delete and exclusive set to false

### DIFF
--- a/src/rabbit_amqp1_0_incoming_link.erl
+++ b/src/rabbit_amqp1_0_incoming_link.erl
@@ -193,6 +193,8 @@ ensure_target(Target = #'v1_0.target'{address       = Address,
                                       timeout       = _Timeout},
               Link = #incoming_link{ route_state = RouteState }, DCh) ->
     DeclareParams = [{durable, rabbit_amqp1_0_link_util:durable(Durable)},
+                     {exclusive, false},
+                     {auto_delete, false},
                      {check_exchange, true},
                      {nowait, false}],
     case Dynamic of

--- a/src/rabbit_amqp1_0_outgoing_link.erl
+++ b/src/rabbit_amqp1_0_outgoing_link.erl
@@ -157,6 +157,8 @@ ensure_source(Source = #'v1_0.source'{address       = Address,
                                       timeout       = _Timeout},
               Link = #outgoing_link{ route_state = RouteState }, DCh) ->
     DeclareParams = [{durable, rabbit_amqp1_0_link_util:durable(Durable)},
+                     {exclusive, false},
+                     {auto_delete, false},
                      {check_exchange, true},
                      {nowait, false}],
     case Dynamic of


### PR DESCRIPTION
Since rabbitmq/rabbitmq-erlang-client#16, the `durable` parameter is honored (instead of being forced to true). So AMQP 1.0 queues are created as non-durable.

In our Erlang AMQP client, this means the queue is created with auto-delete and exclusive set to true by default. We must explicitely set those to false.

The testsuite is expanded to check that AMQP 0-9-1 queues created out-of-band can be properly used from AMQP 1.0, no matter their parameters.

Fixes #22.