### PR TITLE
.gitignore: make absolute paths relative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,20 @@
 .sw?
 .*.sw?
 *.beam
-/.erlang.mk/
-/cover/
-/deps/
-/doc/
-/ebin/
-/logs/
-/plugins/
+.erlang.mk/
+cover/
+deps/
+doc/
+ebin/
+logs/
+plugins/
 
-/rabbitmq_amqp1_0.d
+rabbitmq_amqp1_0.d
 
 # Generated source files.
-/include/rabbit_amqp1_0_framing.hrl
-/src/rabbit_amqp1_0_framing0.erl
+include/rabbit_amqp1_0_framing.hrl
+src/rabbit_amqp1_0_framing0.erl
 
 # Swift.
-/test/swiftmq/swiftmq_*_client.tar.gz
-/test/swiftmq/build/
+test/swiftmq/swiftmq_*_client.tar.gz
+test/swiftmq/build/


### PR DESCRIPTION
When this repo is a dependency of another one, and only the other one `.git`'s folder is used, the absolute paths git-ignoring apply to the parent project too; thus possibly ignoring files from the parent project.
And really, there's no need to make these paths absolute.

Note: relative paths in `.gitignore` apply as if this file was located at `/.gitignore`.