### PR TITLE
Use the new -spec format

### DIFF
--- a/src/rabbit_amqp1_0_binary_generator.erl
+++ b/src/rabbit_amqp1_0_binary_generator.erl
@@ -21,10 +21,8 @@
 
 -include("rabbit_amqp1_0.hrl").
 
--ifdef(use_specs).
--spec(generate/1 :: (tuple()) -> iolist()).
--spec(build_frame/2 :: (int(), iolist()) -> iolist()).
--endif.
+-spec generate(tuple()) -> iolist().
+-spec build_frame(integer(), iolist()) -> iolist().
 
 -define(AMQP_FRAME_TYPE, 0).
 -define(DOFF, 2).

--- a/src/rabbit_amqp1_0_binary_parser.erl
+++ b/src/rabbit_amqp1_0_binary_parser.erl
@@ -20,9 +20,7 @@
 
 -include("rabbit_amqp1_0.hrl").
 
--ifdef(use_specs).
--spec(parse/1 :: (binary()) -> tuple()).
--endif.
+-spec parse(binary()) -> tuple().
 
 parse_all(ValueBin) when is_binary(ValueBin) ->
     lists:reverse(parse_all([], parse(ValueBin))).

--- a/src/rabbit_amqp1_0_session_sup.erl
+++ b/src/rabbit_amqp1_0_session_sup.erl
@@ -26,19 +26,14 @@
 
 %%----------------------------------------------------------------------------
 
--ifdef(use_specs).
-
 -export_type([start_link_args/0]).
 
--type(start_link_args() ::
+-type start_link_args() ::
         {rabbit_types:protocol(), rabbit_net:socket(),
          rabbit_channel:channel_number(), non_neg_integer(), pid(),
-         rabbit_access_control:username(), rabbit_types:vhost(), pid()}).
+         rabbit_access_control:username(), rabbit_types:vhost(), pid()}.
 
--spec(start_link/1 :: (start_link_args()) -> {'ok', pid(), pid()}).
-
--endif.
-
+-spec start_link(start_link_args()) -> {'ok', pid(), pid()}.
 
 %%----------------------------------------------------------------------------
 start_link({rabbit_amqp1_0_framing, Sock, Channel, FrameMax, ReaderPid,

--- a/src/rabbit_amqp1_0_session_sup_sup.erl
+++ b/src/rabbit_amqp1_0_session_sup_sup.erl
@@ -27,13 +27,9 @@
 
 %%----------------------------------------------------------------------------
 
--ifdef(use_specs).
-
--spec(start_link/0 :: () -> rabbit_types:ok_pid_or_error()).
--spec(start_session/2 :: (pid(), rabbit_amqp1_0_session_sup:start_link_args()) ->
-                              {'ok', pid(), pid()}).
-
--endif.
+-spec start_link() -> rabbit_types:ok_pid_or_error().
+-spec start_session(pid(), rabbit_amqp1_0_session_sup:start_link_args()) ->
+                              {'ok', pid(), pid()}.
 
 %%----------------------------------------------------------------------------
 

--- a/src/rabbit_amqp1_0_util.erl
+++ b/src/rabbit_amqp1_0_util.erl
@@ -21,21 +21,16 @@
 -export([protocol_error/3]).
 -export([serial_add/2, serial_compare/2, serial_diff/2]).
 
--ifdef(use_specs).
-
 -export_type([serial_number/0]).
--type(serial_number() :: non_neg_integer()).
--type(serial_compare_result() :: 'equal' | 'less' | 'greater').
+-type serial_number() :: non_neg_integer().
+-type serial_compare_result() :: 'equal' | 'less' | 'greater'.
 
--spec(serial_add/2 :: (serial_number(), non_neg_integer()) ->
-             serial_number()).
--spec(serial_compare/2 :: (serial_number(), serial_number()) ->
-             serial_compare_result()).
--spec(serial_diff/2 :: (serial_number(), serial_number()) ->
-             integer()).
-
--endif.
-
+-spec serial_add(serial_number(), non_neg_integer()) ->
+             serial_number().
+-spec serial_compare(serial_number(), serial_number()) ->
+             serial_compare_result().
+-spec serial_diff(serial_number(), serial_number()) ->
+             integer().
 
 protocol_error(Condition, Msg, Args) ->
     exit(#'v1_0.error'{

--- a/src/rabbit_amqp1_0_writer.erl
+++ b/src/rabbit_amqp1_0_writer.erl
@@ -36,52 +36,48 @@
 
 %%---------------------------------------------------------------------------
 
--ifdef(use_specs).
-
--spec(start/5 ::
+-spec start
         (rabbit_net:socket(), rabbit_channel:channel_number(),
          non_neg_integer(), rabbit_types:protocol(), pid())
-        -> rabbit_types:ok(pid())).
--spec(start_link/5 ::
+        -> rabbit_types:ok(pid()).
+-spec start_link
         (rabbit_net:socket(), rabbit_channel:channel_number(),
          non_neg_integer(), rabbit_types:protocol(), pid())
-        -> rabbit_types:ok(pid())).
--spec(start/6 ::
+        -> rabbit_types:ok(pid()).
+-spec start
         (rabbit_net:socket(), rabbit_channel:channel_number(),
          non_neg_integer(), rabbit_types:protocol(), pid(), boolean())
-        -> rabbit_types:ok(pid())).
--spec(start_link/6 ::
+        -> rabbit_types:ok(pid()).
+-spec start_link
         (rabbit_net:socket(), rabbit_channel:channel_number(),
          non_neg_integer(), rabbit_types:protocol(), pid(), boolean())
-        -> rabbit_types:ok(pid())).
--spec(send_command/2 ::
-        (pid(), rabbit_framing:amqp_method_record()) -> 'ok').
--spec(send_command/3 ::
+        -> rabbit_types:ok(pid()).
+-spec send_command
+        (pid(), rabbit_framing:amqp_method_record()) -> 'ok'.
+-spec send_command
         (pid(), rabbit_framing:amqp_method_record(), rabbit_types:content())
-        -> 'ok').
--spec(send_command_sync/2 ::
-        (pid(), rabbit_framing:amqp_method_record()) -> 'ok').
--spec(send_command_sync/3 ::
+        -> 'ok'.
+-spec send_command_sync
+        (pid(), rabbit_framing:amqp_method_record()) -> 'ok'.
+-spec send_command_sync
         (pid(), rabbit_framing:amqp_method_record(), rabbit_types:content())
-        -> 'ok').
--spec(send_command_and_notify/4 ::
+        -> 'ok'.
+-spec send_command_and_notify
         (pid(), pid(), pid(), rabbit_framing:amqp_method_record())
-        -> 'ok').
--spec(send_command_and_notify/5 ::
+        -> 'ok'.
+-spec send_command_and_notify
         (pid(), pid(), pid(), rabbit_framing:amqp_method_record(),
          rabbit_types:content())
-        -> 'ok').
--spec(internal_send_command/4 ::
+        -> 'ok'.
+-spec internal_send_command
         (rabbit_net:socket(), rabbit_channel:channel_number(),
          rabbit_framing:amqp_method_record(), rabbit_types:protocol())
-        -> 'ok').
--spec(internal_send_command/6 ::
+        -> 'ok'.
+-spec internal_send_command
         (rabbit_net:socket(), rabbit_channel:channel_number(),
          rabbit_framing:amqp_method_record(), rabbit_types:content(),
          non_neg_integer(), rabbit_types:protocol())
-        -> 'ok').
-
--endif.
+        -> 'ok'.
 
 %%---------------------------------------------------------------------------
 


### PR DESCRIPTION
The old format is removed in Erlang 19.0, leading to build errors.

Also, get rid of the `use_specs` macro and thus always define `-spec()` & friends.

While here, unnify the style of `-type` and `-spec`.

References rabbitmq/rabbitmq-server#860.
[#118562897]
[#122335241]