### PR TITLE
Tag arrays as arrays, not lists

### DIFF
--- a/src/rabbit_amqp1_0_binary_parser.erl
+++ b/src/rabbit_amqp1_0_binary_parser.erl
@@ -93,9 +93,9 @@ parse_primitive(16#d1,<<S:32/unsigned,CountAndValue:S/binary,R/binary>>) ->
 
 %% Arrays
 parse_primitive(16#e0,<<S:8/unsigned,CountAndV:S/binary,R/binary>>) ->
-    {{list, parse_array(8, CountAndV)}, R};
+    {{array, parse_array(8, CountAndV)}, R};
 parse_primitive(16#f0,<<S:32/unsigned,CountAndV:S/binary,R/binary>>) ->
-    {{list, parse_array(32, CountAndV)}, R};
+    {{array, parse_array(32, CountAndV)}, R};
 
 %% NaN or +-inf
 parse_primitive(16#72, <<V:32, R/binary>>) ->

--- a/src/rabbit_amqp1_0_link_util.erl
+++ b/src/rabbit_amqp1_0_link_util.erl
@@ -40,7 +40,7 @@ outcomes(Source) ->
                       end,
                 Os1 = case Os of
                           undefined    -> ?OUTCOMES;
-                          {list, Syms} -> Syms;
+                          {array, Syms} -> Syms;
                           Bad1         -> rabbit_amqp1_0_util:protocol_error(
                                             ?V_1_0_AMQP_ERROR_NOT_IMPLEMENTED,
                                             "Outcomes not supported: ~p",


### PR DESCRIPTION
Fixes #35 

Outcomes are already covered by the dotnet test suite, however it appears this client is lenient in it's parsing of lists/arrays. Spec states Outcomes should be encoded as arrays.