### PR TITLE
Fix typo in x-credit arguments.

### DIFF
--- a/src/rabbit_amqp1_0_outgoing_link.erl
+++ b/src/rabbit_amqp1_0_outgoing_link.erl
@@ -67,7 +67,7 @@ attach(#'v1_0.attach'{name = Name,
                      exclusive = false,
                      arguments = [{<<"x-credit">>, table,
                                    [{<<"credit">>, long,    0},
-                                    {<<"drain">>,  boolean, false}]}]},
+                                    {<<"drain">>,  bool, false}]}]},
                    self()) of
                 #'basic.consume_ok'{} ->
                     %% TODO we should avoid the race by getting the queue to send


### PR DESCRIPTION
This caused the credit mechanism not to to initialise correctly
with the channel limiter which had the effect that the amqp1.0 plugin
would start delivering messages before credit had been granted.

[#144860529]

Fixes #43 