### PR TITLE
Erlang/OTP 19.2 is now the minimum supported version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,11 @@ addons:
       - elixir
       - dotnet-dev-1.0.0-preview2-003156
       - xsltproc
+
 otp_release:
-  - "18.3"
-  - "19.0"
+  - "19.2"
+  - "19.3"
+  - "20.0"
 
 before_script:
   # The checkout made by Travis is a "detached HEAD" and branches


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#1305.

[#149563549]