### PR TITLE
Erlang/OTP 21 compatibility

### DIFF
--- a/src/rabbit_amqp1_0_reader.erl
+++ b/src/rabbit_amqp1_0_reader.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_amqp1_0_reader).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbit_common/include/rabbit_framing.hrl").
 -include_lib("kernel/include/inet.hrl").

--- a/src/rabbit_amqp1_0_session_process.erl
+++ b/src/rabbit_amqp1_0_session_process.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_amqp1_0_session_process).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 -behaviour(gen_server2).
 
 -export([init/1, terminate/2, code_change/3,


### PR DESCRIPTION
This is a backport of #64.

References rabbitmq/rabbitmq-server#1616.