### PR TITLE
Add test for quorum queues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endef
 
 BUILD_DEPS = rabbitmq_codegen
 DEPS = rabbit_common rabbit amqp_client amqp10_common
-TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp10_client
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/src/rabbit_amqp1_0_outgoing_link.erl
+++ b/src/rabbit_amqp1_0_outgoing_link.erl
@@ -16,7 +16,7 @@
 
 -module(rabbit_amqp1_0_outgoing_link).
 
--export([attach/3, delivery/6, transferred/3, credit_drained/4, flow/3]).
+-export([attach/3, delivery/6, transferred/3, credit_drained/3, flow/3]).
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include("rabbit_amqp1_0.hrl").
@@ -98,8 +98,7 @@ attach(#'v1_0.attach'{name = Name,
     end.
 
 credit_drained(#'basic.credit_drained'{credit_drained = CreditDrained},
-               Handle, Link = #outgoing_link{delivery_count = Count0},
-               WriterPid) ->
+               Handle, Link = #outgoing_link{delivery_count = Count0}) ->
     Count = Count0 + CreditDrained,
     %% The transfer count that is given by the queue should be at
     %% least that we have locally, since we will either have received
@@ -112,8 +111,8 @@ credit_drained(#'basic.credit_drained'{credit_drained = CreditDrained},
                       link_credit = {uint, 0},
                       available   = {uint, 0},
                       drain       = true },
-    rabbit_amqp1_0_writer:send_command(WriterPid, F),
-    Link#outgoing_link{delivery_count = Count}.
+    % rabbit_amqp1_0_writer:send_command(WriterPid, F),
+    {F, Link#outgoing_link{delivery_count = Count}}.
 
 flow(#outgoing_link{delivery_count = LocalCount},
      #'v1_0.flow'{handle         = Handle,

--- a/src/rabbit_amqp1_0_outgoing_link.erl
+++ b/src/rabbit_amqp1_0_outgoing_link.erl
@@ -111,7 +111,6 @@ credit_drained(#'basic.credit_drained'{credit_drained = CreditDrained},
                       link_credit = {uint, 0},
                       available   = {uint, 0},
                       drain       = true },
-    % rabbit_amqp1_0_writer:send_command(WriterPid, F),
     {F, Link#outgoing_link{delivery_count = Count}}.
 
 flow(#outgoing_link{delivery_count = LocalCount},

--- a/test/amqp10_client_SUITE.erl
+++ b/test/amqp10_client_SUITE.erl
@@ -1,0 +1,152 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ Federation.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(amqp10_client_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("rabbit_common/include/rabbit_framing.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+      {group, tests}
+    ].
+
+groups() ->
+    [
+     {tests, [], [
+                  roundtrip_quorum_queue_with_drain
+                 ]}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    application:ensure_all_started(amqp10_client),
+    rabbit_ct_helpers:log_environment(),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_group(Group, Config) ->
+    Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
+    Config1 = rabbit_ct_helpers:set_config(
+                Config, [
+                         {rmq_nodename_suffix, Suffix},
+                         {amqp10_client_library, Group}
+                        ]),
+    rabbit_ct_helpers:run_setup_steps(Config1,
+                                      rabbit_ct_broker_helpers:setup_steps() ++
+                                      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_group(_, Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%%% TESTS
+%%%
+
+roundtrip_quorum_queue_with_drain(Config) ->
+    Host = ?config(rmq_hostname, Config),
+    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
+    QName  = atom_to_binary(?FUNCTION_NAME, utf8),
+    Address = <<"/amq/queue/", QName/binary>>,
+    %% declare a quorum queue
+    Ch = rabbit_ct_client_helpers:open_channel(Config, 0),
+    amqp_channel:call(Ch, #'queue.declare'{queue = QName,
+                                           durable = true,
+                                           arguments = [{<<"x-queue-type">>, longstr, <<"quorum">>}]}),
+    % create a configuration map
+    OpnConf = #{address => Host,
+                port => Port,
+                container_id => atom_to_binary(?FUNCTION_NAME, utf8),
+                sasl => {plain, <<"guest">>, <<"guest">>}},
+    % ct:pal("opening connectoin with ~p", [OpnConf]),
+    {ok, Connection} = amqp10_client:open_connection(OpnConf),
+    {ok, Session} = amqp10_client:begin_session(Connection),
+    SenderLinkName = <<"test-sender">>,
+    {ok, Sender} = amqp10_client:attach_sender_link(Session,
+                                                    SenderLinkName,
+                                                    Address),
+
+    % wait for credit to be received
+    receive
+        {amqp10_event, {link, Sender, credited}} -> ok
+    after 2000 ->
+              exit(credited_timeout)
+    end,
+
+    % create a new message using a delivery-tag, body and indicate
+    % it's settlement status (true meaning no disposition confirmation
+    % will be sent by the receiver).
+    OutMsg = amqp10_msg:new(<<"my-tag">>, <<"my-body">>, true),
+    ok = amqp10_client:send_msg(Sender, OutMsg),
+
+    flush("pre-receive"),
+    % create a receiver link
+    {ok, Receiver} = amqp10_client:attach_receiver_link(Session,
+                                                        <<"test-receiver">>,
+                                                        Address),
+
+    % grant credit and drain
+    ok = amqp10_client:flow_link_credit(Receiver, 5, never, true),
+
+    % wait for a delivery
+    receive
+        {amqp10_msg, Receiver, _InMsg} -> ok
+    after 2000 ->
+              exit(delivery_timeout)
+    end,
+    OutMsg2 = amqp10_msg:new(<<"my-tag">>, <<"my-body2">>, true),
+    ok = amqp10_client:send_msg(Sender, OutMsg2),
+
+    %% no delivery should be made at this point
+    receive
+        {amqp10_msg, _, _} ->
+            exit(unexpected_delivery)
+    after 500 ->
+              ok
+    end,
+
+    flush("final"),
+    ok = amqp10_client:detach_link(Sender),
+
+    ok = amqp10_client:close_connection(Connection),
+    ok.
+
+
+%% internal
+%%
+
+flush(Prefix) ->
+    receive
+        Msg ->
+            ct:pal("~s flushed: ~w~n", [Prefix, Msg]),
+            flush(Prefix)
+    after 1 ->
+              ok
+    end.


### PR DESCRIPTION
As well as a minor change ensure that all flow frames always have mandatory fields set.

This is mostly testing changes in other repositories such as the
amqp_client and rabbit server to enable quorum queue credit support as
well as letting credit_drained messages through the amqp client.

[#161256187]