### PR TITLE
URL Cleanup

### DIFF
--- a/test/system_SUITE_data/java-tests/mvnw
+++ b/test/system_SUITE_data/java-tests/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/test/system_SUITE_data/java-tests/mvnw.cmd
+++ b/test/system_SUITE_data/java-tests/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/test/system_SUITE_data/java-tests/pom.xml
+++ b/test/system_SUITE_data/java-tests/pom.xml
@@ -6,7 +6,7 @@
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
   <name>rabbitmq-amqp1.0-java-tests</name>
-  <url>http://www.rabbitmq.com</url>
+  <url>https://www.rabbitmq.com</url>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.rabbitmq.com migrated to:  
  https://www.rabbitmq.com ([https](https://www.rabbitmq.com) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance