### PR TITLE
better handle resource access failures

### DIFF
--- a/src/rabbit_amqp1_0_channel.erl
+++ b/src/rabbit_amqp1_0_channel.erl
@@ -20,7 +20,7 @@
 -include("rabbit_amqp1_0.hrl").
 
 -export([call/2, call/3, cast/2, cast/3, cast_flow/3, subscribe/3]).
--export([convert_error/1]).
+-export([convert_code/1, convert_error/1]).
 
 -import(rabbit_amqp1_0_util, [protocol_error/3]).
 

--- a/test/amqp10_client_SUITE.erl
+++ b/test/amqp10_client_SUITE.erl
@@ -130,7 +130,7 @@ roundtrip_quorum_queue_with_drain(Config) ->
                                                         Address),
 
     % grant credit and drain
-    ok = amqp10_client:flow_link_credit(Receiver, 5, never, true),
+    ok = amqp10_client:flow_link_credit(Receiver, 1, never, true),
 
     % wait for a delivery
     receive

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -43,7 +43,9 @@ groups() ->
           redelivery,
           routing,
           invalid_routes,
-          auth_failure
+          auth_failure,
+          access_failure,
+          access_failure_send
         ]},
       {java, [], [
           roundtrip
@@ -191,6 +193,26 @@ invalid_routes(Config) ->
 
 auth_failure(Config) ->
     run(Config, [ {dotnet, "auth_failure"} ]).
+
+access_failure(Config) ->
+    User = <<"access_failure">>,
+    rabbit_ct_broker_helpers:add_user(Config, User, <<"boo">>),
+    rabbit_ct_broker_helpers:set_permissions(Config, User, <<"/">>,
+                                             <<".*">>, %% configure
+                                             <<"^banana.*">>, %% write
+                                             <<"^banana.*">>  %% read
+                                            ),
+    run(Config, [ {dotnet, "access_failure"} ]).
+
+access_failure_send(Config) ->
+    User = <<"access_failure_send">>,
+    rabbit_ct_broker_helpers:add_user(Config, User, <<"boo">>),
+    rabbit_ct_broker_helpers:set_permissions(Config, User, <<"/">>,
+                                             <<".*">>, %% configure
+                                             <<"^banana.*">>, %% write
+                                             <<"^banana.*">>  %% read
+                                            ),
+    run(Config, [ {dotnet, "access_failure_send"} ]).
 
 run(Config, Flavors) ->
     ClientLibrary = ?config(amqp10_client_library, Config),


### PR DESCRIPTION
Handle amqp channel exits that may occur e.g when the user has
insufficient permissions to publish to an exchange resource.

Requires: https://github.com/rabbitmq/rabbitmq-server/pull/2004