### PR TITLE
Get default_vhost setting from rabbitmq_amqp1_0 application first.

### DIFF
--- a/src/rabbit_amqp1_0_reader.erl
+++ b/src/rabbit_amqp1_0_reader.erl
@@ -635,7 +635,7 @@ auth_mechanism_to_module(TypeBin, Sock) ->
     end.
 
 auth_mechanisms(Sock) ->
-    {ok, Configured} = application:get_env(auth_mechanisms),
+    {ok, Configured} = application:get_env(rabbit, auth_mechanisms),
     [Name || {Name, Module} <- rabbit_registry:lookup_all(auth_mechanism),
              Module:should_offer(Sock), lists:member(Name, Configured)].
 
@@ -706,8 +706,8 @@ send_to_new_1_0_session(Channel, Frame, State) ->
 vhost({utf8, <<"vhost:", VHost/binary>>}) ->
     VHost;
 vhost(_) ->
-    {ok, DefaultVHost} = application:get_env(default_vhost),
-    DefaultVHost.
+    application:get_env(rabbitmq_amqp1_0, default_vhost,
+                        application:get_env(rabbit, default_vhost, <<"/">>)).
 
 %% End 1-0
 


### PR DESCRIPTION
If application is not specified, the `rabbit` application is used
by default. Documentation mentions setting this configuration in
the `rabbitmq_amqp1_0` application.
Make it use the `rabbitmq_amqp1_0` setting first and then `rabbit`

[#165802050]