### PR TITLE
Gracefully handle refused access in session process

### DIFF
--- a/src/rabbit_amqp1_0_session_sup.erl
+++ b/src/rabbit_amqp1_0_session_sup.erl
@@ -50,14 +50,17 @@ start_link({amqp10_framing, Sock, Channel, FrameMax, ReaderPid,
         undefined -> Sock;
         _         -> ProxySocket
     end,
-    {ok, ChannelPid} =
-        supervisor2:start_child(
-          SupPid,
-          {channel, {rabbit_amqp1_0_session_process, start_link,
-                     [{Channel, ReaderPid, WriterPid, Username, VHost, FrameMax,
-                       adapter_info(SocketForAdapterInfo), Collector}]},
-           intrinsic, ?WORKER_WAIT, worker, [rabbit_amqp1_0_session_process]}),
-    {ok, SupPid, ChannelPid}.
+    case supervisor2:start_child(
+           SupPid,
+           {channel, {rabbit_amqp1_0_session_process, start_link,
+                      [{Channel, ReaderPid, WriterPid, Username, VHost, FrameMax,
+                        adapter_info(SocketForAdapterInfo), Collector}]},
+            intrinsic, ?WORKER_WAIT, worker, [rabbit_amqp1_0_session_process]}) of
+        {ok, ChannelPid} ->
+            {ok, SupPid, ChannelPid};
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 %%----------------------------------------------------------------------------
 

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -45,6 +45,7 @@ groups() ->
           invalid_routes,
           auth_failure,
           access_failure,
+          access_failure_not_allowed,
           access_failure_send
         ]},
       {java, [], [
@@ -203,6 +204,11 @@ access_failure(Config) ->
                                              <<"^banana.*">>  %% read
                                             ),
     run(Config, [ {dotnet, "access_failure"} ]).
+
+access_failure_not_allowed(Config) ->
+    User = <<"access_failure_not_allowed">>,
+    rabbit_ct_broker_helpers:add_user(Config, User, <<"boo">>),
+    run(Config, [ {dotnet, "access_failure_not_allowed"} ]).
 
 access_failure_send(Config) ->
     User = <<"access_failure_send">>,

--- a/test/system_SUITE_data/fsharp-tests/Program.fs
+++ b/test/system_SUITE_data/fsharp-tests/Program.fs
@@ -406,6 +406,20 @@ module Test =
             printfn "Exception %A" ex
             ()
 
+    let accessFailureNotAllowed uri =
+        try
+            let u = Uri uri
+            let uri = sprintf "amqp://access_failure_not_allowed:boo@%s:%i" u.Host u.Port
+            use ac = connect uri
+            let dest = "/amq/queue/test"
+            let receiver = ReceiverLink(ac.Session, "test-receiver", dest)
+            receiver.Close()
+            failwith "expected exception not received"
+        with
+        | :? Amqp.AmqpException as ex ->
+            printfn "Exception %A" ex
+            ()
+
 let (|AsLower|) (s: string) =
     match s with
     | null -> null
@@ -419,6 +433,9 @@ let main argv =
         0
     | [AsLower "access_failure"; uri] ->
         accessFailure uri
+        0
+    | [AsLower "access_failure_not_allowed"; uri] ->
+        accessFailureNotAllowed uri
         0
     | [AsLower "access_failure_send"; uri] ->
         accessFailureSend uri


### PR DESCRIPTION
Closes https://github.com/rabbitmq/rabbitmq-amqp1.0/issues/87

New logs and trace:
```
2019-08-18 17:24:30.749 [info] <0.670.0> accepting AMQP connection <0.670.0> ([::1]:52364 -> [::1]:21000)
2019-08-18 17:24:30.792 [warning] <0.677.0> Closing session for connection <0.670.0>:
not_allowed
2019-08-18 17:24:30.792 [error] <0.677.0> CRASH REPORT Process <0.677.0> with 0 neighbours exited with reason: not_allowed in gen_server2:init_it/6 line 600
2019-08-18 17:24:30.792 [error] <0.670.0> AMQP 1.0 connection <0.670.0> (running), channel 0 - error:
<<"Reader error: {error,{not_allowed,<<\"access_failure_not_allowed\">>}}\n[{rabbit_amqp1_0_reader,send_to_new_1_0_session,3,\n                        [{file,\"src/rabbit_amqp1_0_reader.erl\"},{line,707}]},\n {rabbit_amqp1_0_reader,handle_1_0_session_frame,3,\n                        [{file,\"src/rabbit_amqp1_0_reader.erl\"},{line,467}]},\n {rabbit_amqp1_0_reader,handle_1_0_frame,4,\n                        [{file,\"src/rabbit_amqp1_0_reader.erl\"},{line,321}]},\n {rabbit_amqp1_0_reader,recvloop,2,\n                        [{file,\"src/rabbit_amqp1_0_reader.erl\"},{line,123}]},\n {rabbit_reader,run,1,[{file,\"src/rabbit_reader.erl\"},{line,471}]},\n {rabbit_reader,start_connection,4,\n                [{file,\"src/rabbit_reader.erl\"},{line,370}]},\n {proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,249}]}]\n">>
2019-08-18 17:24:30.797 [info] <0.670.0> closing AMQP connection <0.670.0> ([::1]:52364 -> [::1]:21000)
```